### PR TITLE
Update workshop title from 'AI on AnVIL?' to 'AI in AnVIL with RStudio'

### DIFF
--- a/p2_w1.Rmd
+++ b/p2_w1.Rmd
@@ -1,6 +1,6 @@
 # (PART\*) Part 2 Workshops {-}
 
-# AI on AnVIL?
+# AI in AnVIL with RStudio
 
 Led by:
 

--- a/p2_w2.Rmd
+++ b/p2_w2.Rmd
@@ -1,4 +1,4 @@
-# Imputation?
+# All of Us and AnVIL Imputation Service
 
 Led by: 
 


### PR DESCRIPTION
Updating workshop names based on the website advertisement for ACC: https://anvilproject.org/events/anvil2026-community-conference
